### PR TITLE
Draft: MacOS requires GCC and libpq-dev in order to install psycopg2

### DIFF
--- a/.docker/api/Dockerfile
+++ b/.docker/api/Dockerfile
@@ -8,7 +8,7 @@ ENV POETRY_VIRTUALENVS_CREATE=false
 WORKDIR /app
 
 RUN apt-get update && apt-get upgrade -y
-RUN apt-get install git tini -y
+RUN apt-get install git tini libpq-dev gcc -y
 
 RUN pip install --upgrade pip
 RUN pip install poetry

--- a/.docker/scraper/Dockerfile
+++ b/.docker/scraper/Dockerfile
@@ -7,7 +7,7 @@ ENV POETRY_VIRTUALENVS_CREATE=false
 
 WORKDIR /app
 
-RUN apt-get update && apt-get upgrade -y && apt-get install git tini -y
+RUN apt-get update && apt-get upgrade -y && apt-get install git tini libpq-dev gcc -y
 RUN pip install --upgrade pip
 RUN pip install poetry
 


### PR DESCRIPTION
## MacOS requires GCC and libpq-dev 

### Summary

added dependencies to fix macos build 

### What has been added

- `apt-get install libpq-dev gcc -y`