### PR TITLE
Custom pagination

### DIFF
--- a/applications/tweets/custom_pagination.py
+++ b/applications/tweets/custom_pagination.py
@@ -1,0 +1,12 @@
+from rest_framework.pagination import PageNumberPagination
+
+
+class LocationPagination(PageNumberPagination):
+    """
+    Custom pagination for the location API.
+
+    Max page size is set to 100 and can be changed depending on our choice.
+    """
+    page_size_query_param = "page_size"
+    max_page_size = 100
+    page_size = 20

--- a/applications/tweets/views.py
+++ b/applications/tweets/views.py
@@ -1,4 +1,6 @@
 from rest_framework.viewsets import ModelViewSet
+
+from tweets.custom_pagination import LocationPagination
 from tweets.models import Location
 from tweets.serializers import LocationSerializer
 
@@ -7,3 +9,4 @@ class LocationViewSet(ModelViewSet):
     queryset = Location.objects.select_related("address", "address__tweet").all()
     serializer_class = LocationSerializer
     http_method_names = ["options", "head", "get"]
+    pagination_class = LocationPagination


### PR DESCRIPTION
## Custom Pagination

### Summary

Created custom pagination so front end can use `page_size` as a query parameter to determine how many articles they want to see for a page, set maximum to 100.

### What has been added

- Custom Pagination
- `pagination_class` in `LocationViewSet`