### PR TITLE
add `build-essential` to Dockerfile deps

### DIFF
--- a/.docker/api/Dockerfile
+++ b/.docker/api/Dockerfile
@@ -8,7 +8,7 @@ ENV POETRY_VIRTUALENVS_CREATE=false
 WORKDIR /app
 
 RUN apt-get update && apt-get upgrade -y
-RUN apt-get install git tini -y
+RUN apt-get install git tini build-essential -y
 
 RUN pip install --upgrade pip
 RUN pip install poetry

--- a/.docker/scraper/Dockerfile
+++ b/.docker/scraper/Dockerfile
@@ -7,7 +7,7 @@ ENV POETRY_VIRTUALENVS_CREATE=false
 
 WORKDIR /app
 
-RUN apt-get update && apt-get upgrade -y && apt-get install git tini -y
+RUN apt-get update && apt-get upgrade -y && apt-get install git tini build-essential -y
 RUN pip install --upgrade pip
 RUN pip install poetry
 

--- a/docker/development/Dockerfile
+++ b/docker/development/Dockerfile
@@ -9,7 +9,7 @@ ENV POETRY_VIRTUALENVS_CREATE=false
 WORKDIR /app
 
 RUN apt-get update && apt-get upgrade -y
-RUN apt-get install git -y
+RUN apt-get install git build-essential -y
 
 RUN pip install --upgrade pip
 RUN pip install poetry


### PR DESCRIPTION
Dockerfiles were not working on macos M1. This PR fixes this issue.