### PR TITLE
fix: update the default CELERY_BROKER_URL to match the docker-compose file

### DIFF
--- a/trquake/settings/base.py
+++ b/trquake/settings/base.py
@@ -139,7 +139,7 @@ STATIC_ROOT = BASE_DIR / "statics" / "root"
 DEFAULT_AUTO_FIELD = "django.db.models.BigAutoField"
 
 
-CELERY_BROKER_URL = env.str("CELERY_BROKER_URL", "redis://trquake-queue:6379")
+CELERY_BROKER_URL = env.str("CELERY_BROKER_URL", "redis://trquake-redis:6379")
 CELERY_ACCEPT_CONTENT = ["json"]
 CELERY_TASK_SERIALIZER = "json"
 CELERY_RESULT_SERIALIZER = "json"


### PR DESCRIPTION
This PR simply updates the default CELERY_BROKER_URL defined in the django settings to match the docker-compose file