### PR TITLE
fix: Don't use django debug mode on production

### DIFF
--- a/trquake/settings/production.py
+++ b/trquake/settings/production.py
@@ -3,7 +3,7 @@ import environ
 
 env = environ.Env()
 
-DEBUG = True
+DEBUG = False
 ALLOWED_HOSTS = ["*"]
 # CORS_ALLOWED_ORIGINS = ["https://afetharita.com", "https://api.afetharita.com", "http://api.afetharita.com"]
 CORS_ORIGIN_ALLOW_ALL = True


### PR DESCRIPTION
Django DEBUG mode is being used in production:

![image](https://user-images.githubusercontent.com/11313340/217314968-cfcbd467-82c8-4c89-9438-115e7347c6fa.png)
