### PR TITLE
added address evaluation to handle address collisions

### DIFF
--- a/applications/core/address_api.py
+++ b/applications/core/address_api.py
@@ -1,7 +1,7 @@
 # Applications
 from core.helpers.trendyol_bff import TY_BFF
 from core.helpers.regex_api import ExtractInfo
-
+from core.helpers.address_evaluator import AddressEvaluator
 
 class AddressAPI:
     def __init__(self):
@@ -10,8 +10,18 @@ class AddressAPI:
 
         self.regex_api = ExtractInfo()
 
+        self.address_evaluator = AddressEvaluator()
+
     def trendyol_bff_api_request(self, address_text: str):
-        return self.ty_api.request(address_text)
+        addresses = self.ty_api.request(address_text)
+        busiest_address = self.address_evaluator.get_busiest_address(addresses)
+        return busiest_address
 
     def regex_api_request(self, address_text: str):
         return self.regex_api.extract(address_text)
+
+if __name__ == "__main__":
+    address_api = AddressAPI()
+    address_input = "Necip Fazıl"
+    response = address_api.regex_api_request(address_input)
+    print(response)

--- a/applications/core/address_api.py
+++ b/applications/core/address_api.py
@@ -19,9 +19,3 @@ class AddressAPI:
 
     def regex_api_request(self, address_text: str):
         return self.regex_api.extract(address_text)
-
-if __name__ == "__main__":
-    address_api = AddressAPI()
-    address_input = "Necip Fazıl"
-    response = address_api.regex_api_request(address_input)
-    print(response)

--- a/applications/core/helpers/address_evaluator.py
+++ b/applications/core/helpers/address_evaluator.py
@@ -1,0 +1,64 @@
+# Standard Library
+import json
+
+# Third Party
+import requests
+
+class AddressEvaluator():
+
+    def __init__(self):
+        self.session = requests.session()
+        self.tr_geolocation_centre = {
+                "ne_lat":43.25302605909373,
+                "ne_lng":42.705981743884905,
+                "sw_lat":32.846986448244536,
+                "sw_lng":29.700645139879093
+                }
+        self.afetharita_litearea_api_url = "https://api.afetharita.com/feeds/areas-lite?ne_lat={}&ne_lng={}&sw_lat={}&sw_lng={}".format(self.tr_geolocation_centre["ne_lat"], self.tr_geolocation_centre["ne_lng"], self.tr_geolocation_centre["sw_lat"], self.tr_geolocation_centre["sw_lng"])
+
+    def get_busiest_address(self, addresses):
+
+        busiest_address = addresses[0]
+
+        average_location = self.get_average_location()
+        if average_location is None:
+            return busiest_address
+
+        min_difference = 999.9
+        for address in addresses:
+            latitude_difference = abs(address["latitude"] - average_location[0])
+            longitude_difference = abs(address["longitude"] - average_location[1])
+            difference = latitude_difference + longitude_difference
+
+            if difference < min_difference:
+                min_difference = difference
+                busiest_address = address
+
+        return busiest_address
+
+    def get_average_location(self):
+
+        response = self.session.get(self.afetharita_litearea_api_url)
+        if response.status_code != 200:
+            return None
+
+        response = response.json()
+        all_geolocation_count = response["count"]
+        all_geolocations = response["results"]
+
+        total_latitude = 0.0
+        total_longitude = 0.0
+
+        for geolocation in all_geolocations:
+
+            # loc[0] ~ latitude, loc[1] ~ longitude according to Location model
+            latitude = geolocation["loc"][0]
+            longitude = geolocation["loc"][1]
+
+            total_latitude += latitude
+            total_longitude += longitude
+
+        average_latitude = total_latitude / all_geolocation_count
+        average_longitude = total_longitude / all_geolocation_count
+
+        return [average_latitude, average_longitude]

--- a/applications/core/helpers/trendyol_bff.py
+++ b/applications/core/helpers/trendyol_bff.py
@@ -4,7 +4,6 @@ import json
 # Third Party
 import requests
 
-
 class TY_BFF:
     def __init__(self, api_url):
         self.session = requests.session()
@@ -16,41 +15,45 @@ class TY_BFF:
             return self.response(response.json(), address)
         else:
             return {
-                "address": address,
-                "latitude": 0.0,
-                "longitude": 0.0,
-                "northeast_lat": 0.0,
-                "northeast_lng": 0.0,
-                "southwest_lat": 0.0,
-                "southwest_lng": 0.0,
-                "formatted_address": "",
-                "is_resolved": False,
-            }
+                    "address": address,
+                    "latitude": 0.0,
+                    "longitude": 0.0,
+                    "northeast_lat": 0.0,
+                    "northeast_lng": 0.0,
+                    "southwest_lat": 0.0,
+                    "southwest_lng": 0.0,
+                    "formatted_address": "",
+                    "is_resolved": False,
+                    }
 
     def response(self, response, address):
         if geolocation_results := response.get("results", []):
-            geolocation = geolocation_results[0]
-            geometry = geolocation["geometry"]
-            location = geometry.get("location", {"lat": 0.0, "lng": 0.0})
-            viewport = geometry.get(
+            geolocations = geolocation_results
+            geometries = [geolocation["geometry"] for geolocation in geolocations]
+            locations = [geometry.get("location", {"lat": 0.0, "lng": 0.0}) for geometry in geometries]
+            viewports = [geometry.get(
                 "viewport",
                 {
                     "northeast": {"lat": 0.0, "lng": 0.0},
                     "southwest": {"lat": 0.0, "lng": 0.0},
-                },
-            )
+                    },
+                ) for geometry in geometries]
 
-            return {
-                "address": address,
-                "latitude": location["lat"],
-                "longitude": location["lng"],
-                "northeast_lat": viewport["northeast"]["lat"],
-                "northeast_lng": viewport["northeast"]["lng"],
-                "southwest_lat": viewport["southwest"]["lat"],
-                "southwest_lng": viewport["southwest"]["lng"],
-                "formatted_address": geolocation["formatted_address"],
-                "is_resolved": True,
-            }
+            responses = []
+            for i in range(len(geolocations)):
+                response = {"address": address,
+                            "latitude": locations[i]["lat"],
+                            "longitude": locations[i]["lng"],
+                            "northeast_lat": viewports[i]["northeast"]["lat"],
+                            "northeast_lng": viewports[i]["northeast"]["lng"],
+                            "southwest_lat": viewports[i]["southwest"]["lat"],
+                            "southwest_lng": viewports[i]["southwest"]["lng"],
+                            "formatted_address": geolocations[i]["formatted_address"],
+                            "is_resolved": True
+                        }
+                responses.append(response)
+            return responses
+
         else:
             return {
                 "address": address,
@@ -61,5 +64,5 @@ class TY_BFF:
                 "southwest_lat": 0.0,
                 "southwest_lng": 0.0,
                 "formatted_address": "",
-                "is_resolved": False,
+                "is_resolved": False
             }


### PR DESCRIPTION
## Description
* `trendyol_bff.py` now returns all of the addresses extracted from Trendyol API.
* `address_evaluator.py` finds and returns the optimal (closest to the busiest area) address from provided addresses.
* `address_api.py` evaluates the address just after calling Trendyol API.

## Related Issue
https://github.com/acikkaynak/deprem-yardim-backend/issues/115

## Motivation and Context
* I've seen that Istanbul had around 80 cases, which has no relation with the latest earthquakes in Turkey.
* Previously `trendyol_bff.py` get the first location from Trendyol API which may occur some address collision cases as provided below.
* This commit fixes https://github.com/acikkaynak/deprem-yardim-frontend/issues/494 and the 2nd case of https://github.com/acikkaynak/deprem-yardim-backend/issues/115
* Now the same input generates possibly more accurate address
`{'address': 'Necip Fazıl', 'latitude': 36.8497349, 'longitude': 36.2323796, 'northeast_lat': 36.85111792989272, 'northeast_lng': 36.23378112989273, 'southwest_lat': 36.84841827010728, 'southwest_lng': 36.23108147010728, 'formatted_address': 'Yeşil, 31600 Dörtyol/Hatay, Türkiye', 'is_resolved': True}
`
<img width="402" alt="Screenshot 2023-02-08 at 12 23 42" src="https://user-images.githubusercontent.com/69584310/217630381-8bedb84e-ff3c-4371-ba2c-40c555e7cce4.png">
<img width="1225" alt="Screenshot 2023-02-08 at 22 21 14" src="https://user-images.githubusercontent.com/69584310/217630678-e397fb83-8500-41f6-b239-e3782087e26e.png">
