### PR TITLE
Fix extra_params response type

### DIFF
--- a/applications/feeds/serializers.py
+++ b/applications/feeds/serializers.py
@@ -1,4 +1,5 @@
 # Standard Library
+import json
 from typing import Dict, List, Union
 
 # Rest Framework
@@ -7,6 +8,19 @@ from rest_framework.exceptions import ValidationError
 
 # Applications
 from feeds.models import Entry, Location
+
+
+class JSONSerializerField(serializers.Field):
+
+    def to_representation(self, obj):
+        try:
+            return json.loads(obj)
+        except (ValueError, Exception) as e:
+            # log exception
+            return obj
+
+    def to_internal_value(self, data):
+        return data
 
 
 class BaseEntrySerializer(serializers.ModelSerializer):
@@ -30,6 +44,8 @@ class BulkEntrySerializer(BaseEntrySerializer):
 
 
 class EntrySerializer(BaseEntrySerializer):
+    extra_parameters = JSONSerializerField()
+
     def create(self, validated_data: Dict[str, Union[str, bool]]):
         # Applications
         from feeds.tasks import process_entry


### PR DESCRIPTION
Fix extra_params response type

## Description
The extra_parameters field in the entries does not come as json, but as a string.


## Data Type Changes:
`"extra_parameters": {
            "/user_id/": "/5555555/", "/screen_name/": "/test/",
        }`

to 

`"extra_parameters": {
            "user_id": "5555555",
            "screen_name": "test"
        }`